### PR TITLE
Validador de cpf

### DIFF
--- a/backend/src/main/java/com/justice/justiceforall/service/impl/validator/CPFValidator.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/impl/validator/CPFValidator.java
@@ -1,20 +1,48 @@
 package com.justice.justiceforall.service.impl.validator;
 
+import java.util.Arrays;
+
 import com.justice.justiceforall.entity.UserType;
 import com.justice.justiceforall.exception.InvalidUserFieldException;
 import lombok.experimental.UtilityClass;
-import org.springframework.util.StringUtils;
 
 @UtilityClass
 public class CPFValidator {
 
   private static final String CPF_REGEX = "^[0-9]{11}$";
-
+  //49054926844
   public void validate(String cpf, UserType userType) {
     if (userType == UserType.CLIENT) {
       if (cpf == null || !cpf.matches(CPF_REGEX)) {
         throw new InvalidUserFieldException("The CPF is not properly formatted");
+      }else {
+        int[] digitosOriginais = new int[11];
+        for (int i = 0; i < 11; i++) {
+            digitosOriginais[i] = Character.getNumericValue(cpf.charAt(i));
+        }
+        int[] digitosCopiados = Arrays.copyOf(digitosOriginais, digitosOriginais.length);
+        /////primeiro digito
+        int digito0 = digitoEsperado(digitosOriginais, 0);
+        digitosCopiados[9] = digito0;
+        /////segundo digito
+        int digito1 = digitoEsperado(digitosCopiados, 1);
+        digitosCopiados[10] = digito1;
+        //////validação
+        if(digitosOriginais[9] != digito0 || digitosOriginais[10] != digito1){
+          throw new InvalidUserFieldException("The CPF is not properly formatted");
+        }
       }
     }
+  }
+
+  private int digitoEsperado(int digitos[], int ordem) {
+    int soma = 0;
+    for (int i = 0; i < (9 + ordem); i++) {
+        soma += digitos[i] * ((10+ordem) - i);
+    }
+    int digitoEsperado = 11 - (soma % 11);
+    if (digitoEsperado >= 10)
+      digitoEsperado = 0;
+    return digitoEsperado;
   }
 }

--- a/backend/src/test/java/com/justice/justiceforall/helper/CreateUserCommandFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/CreateUserCommandFixture.java
@@ -14,7 +14,7 @@ public class CreateUserCommandFixture {
         "Email@email.com",
         "password",
         UserType.CLIENT,
-        "10439284154",
+        "32227526726",
         null
     );
   }

--- a/backend/src/test/java/com/justice/justiceforall/helper/UserEntityFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/UserEntityFixture.java
@@ -15,7 +15,7 @@ public class UserEntityFixture {
         "Email@email.com",
         "password",
         UserType.CLIENT,
-        "10439284154",
+        "32227526726",
         null
     );
   }
@@ -28,7 +28,7 @@ public class UserEntityFixture {
         "Email@email.com",
         "password",
         UserType.CLIENT,
-        "10439284154",
+        "32227526726",
         null
     );
   }

--- a/backend/src/test/java/com/justice/justiceforall/helper/UserFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/UserFixture.java
@@ -14,7 +14,7 @@ public class UserFixture {
         "Email@email.com",
         "password",
         UserType.CLIENT,
-        "10439284154",
+        "32227526726",
         null
     );
   }

--- a/backend/src/test/java/com/justice/justiceforall/service/impl/validator/CPFValidatorTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/service/impl/validator/CPFValidatorTests.java
@@ -11,14 +11,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class CPFValidatorTests {
 
-  //cpf correto -> não da exception
-  //cpf invalido -> levanta exception
-  //formato errado -> levanta exception
-  //  
-
   @Test
   void ensureACorrectCPFDoesNotThrowExceptionsWhenValidating() {
-    var correctCpf = "24275465423";
+    var correctCpf = "72169247114";
     assertDoesNotThrow(() -> CPFValidator.validate(correctCpf, UserType.CLIENT));
   }
 

--- a/backend/src/test/java/com/justice/justiceforall/service/impl/validator/CPFValidatorTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/service/impl/validator/CPFValidatorTests.java
@@ -11,15 +11,27 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class CPFValidatorTests {
 
+  //cpf correto -> não da exception
+  //cpf invalido -> levanta exception
+  //formato errado -> levanta exception
+  //  
+
   @Test
   void ensureACorrectCPFDoesNotThrowExceptionsWhenValidating() {
-    var correctCpf = "19438274839";
+    var correctCpf = "24275465423";
     assertDoesNotThrow(() -> CPFValidator.validate(correctCpf, UserType.CLIENT));
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"35938201-21", "4938576982", "123456789101"})
+  @ValueSource(strings = {"35938201-21", "4938576982", "123456789101", "123"})
   void ensureABadFormattedCPFThrowsAnException(String invalidCpf) {
+    assertThrows(InvalidUserFieldException.class,
+        () -> CPFValidator.validate(invalidCpf, UserType.CLIENT));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"24836425646", "19438274839", "35938201212"})
+  void ensureInvalidCPFWithCorrectFormattingThrowsAnException(String invalidCpf) {
     assertThrows(InvalidUserFieldException.class,
         () -> CPFValidator.validate(invalidCpf, UserType.CLIENT));
   }


### PR DESCRIPTION
Foi adicionado um algoritmo para validar o cpf de um cliente. Além disso, modifiquei os testes para cobrir o caso onde o cpf está no formato correto mas é invalido.