### PR TITLE
Feature/Visualizar Casos

### DIFF
--- a/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
+++ b/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.justice.justiceforall.constants.AttributeConstants;
 import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
+import com.justice.justiceforall.dto.casesdto.FilterPaging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,10 +51,12 @@ public class CaseController {
             @RequestParam(name = "userId", required = false) Long userId,
             @RequestParam(name = "lawyerId", required = false) Long lawyerId,
             @RequestParam(name = "category", required = false) String category,
-            @RequestParam(name = "description", required = false) String description
+            @RequestParam(name = "description", required = false) String description,
+            @RequestParam(name = "page", required = false, defaultValue = "1") int pageNumber,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int pageSize
     ) {
-        var filterCasesRequest = new FilterCasesRequest(open, userId, lawyerId, category, description);
-        logger.info("Received a new request to fetch Cases based on the filter {}", filterCasesRequest);
+        var filterCasesRequest = new FilterCasesRequest(open, userId, lawyerId, category, description,
+                new FilterPaging(pageNumber, pageSize));
         return caseService.getFilteredCases(filterCasesRequest);
     }
 

--- a/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
+++ b/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
@@ -5,9 +5,11 @@ import java.util.Collections;
 import java.util.List;
 
 import com.justice.justiceforall.constants.AttributeConstants;
+import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +40,21 @@ public class CaseController {
                 createCaseCommand.category(), userId
         );
         return caseService.createCase(createCaseCommand.withUserId(userId));
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @EndpointAuthentication(authenticationType = AuthenticationType.AUTHENTICATED)
+    public final List<Case> getCases(
+            @RequestParam(name = "open", required = false) Boolean open,
+            @RequestParam(name = "userId", required = false) Long userId,
+            @RequestParam(name = "lawyerId", required = false) Long lawyerId,
+            @RequestParam(name = "category", required = false) String category,
+            @RequestParam(name = "description", required = false) String description
+    ) {
+        var filterCasesRequest = new FilterCasesRequest(open, userId, lawyerId, category, description);
+        logger.info("Received a new request to fetch Cases based on the filter {}", filterCasesRequest);
+        return caseService.getFilteredCases(filterCasesRequest);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
+++ b/backend/src/main/java/com/justice/justiceforall/controllers/CaseController.java
@@ -4,18 +4,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.justice.justiceforall.constants.AttributeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.justice.justiceforall.annotation.EndpointAuthentication;
 import com.justice.justiceforall.config.AuthenticationType;
@@ -34,15 +29,21 @@ public class CaseController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @EndpointAuthentication(authenticationType = AuthenticationType.AUTHENTICATED)
-    public final Case createCase(@RequestBody CreateCaseCommand createCaseCommand) {
-        logger.info("Received a request to create a new case of category {}", createCaseCommand.category());
-        return caseService.createCase(createCaseCommand);
+    public final Case createCase(
+            @RequestAttribute(AttributeConstants.AUTHENTICATED_USER_ID) Long userId,
+            @RequestBody CreateCaseCommand createCaseCommand
+    ) {
+        logger.info(
+                "Received a request to create a new case of category {} for user {}",
+                createCaseCommand.category(), userId
+        );
+        return caseService.createCase(createCaseCommand.withUserId(userId));
     }
-    
+
     @GetMapping("/{id}")
     @EndpointAuthentication(authenticationType = AuthenticationType.AUTHENTICATED)
     public ResponseEntity<Case> getCaseById(@PathVariable Long id) {
-    	logger.info("Received a request to get a case of id {}", id);
+        logger.info("Received a request to get a case of id {}", id);
         Case caseObj = caseService.getCaseById(id);
         if (caseObj != null) {
             return ResponseEntity.ok(caseObj);
@@ -54,7 +55,7 @@ public class CaseController {
     @GetMapping("/all")
     @EndpointAuthentication(authenticationType = AuthenticationType.AUTHENTICATED)
     public ResponseEntity<List<Case>> getAllCases() {
-    	logger.info("Received a request to get all cases");
+        logger.info("Received a request to get all cases");
         Case[] cases = caseService.getAllCases();
         if (cases != null) {
             return ResponseEntity.ok(Arrays.asList(cases));
@@ -66,12 +67,12 @@ public class CaseController {
     @GetMapping("/category/{category}")
     @EndpointAuthentication(authenticationType = AuthenticationType.AUTHENTICATED)
     public ResponseEntity<List<Case>> getCasesByCategory(@PathVariable String category) {
-    	logger.info("Received a request to get all cases of category {}", category);
-    	Case[] cases = caseService.getCasesByCategory(category);
+        logger.info("Received a request to get all cases of category {}", category);
+        Case[] cases = caseService.getCasesByCategory(category);
         if (cases != null) {
             return ResponseEntity.ok(Arrays.asList(cases));
         } else {
-        	return ResponseEntity.ok(Collections.emptyList());
+            return ResponseEntity.ok(Collections.emptyList());
         }
     }
 }

--- a/backend/src/main/java/com/justice/justiceforall/dto/casesdto/Case.java
+++ b/backend/src/main/java/com/justice/justiceforall/dto/casesdto/Case.java
@@ -7,16 +7,16 @@ import lombok.With;
 
 @With
 public record Case(
-	@Getter
-    long caseId,
-    String title,
-    String category,
-    String description,
-    Alegation alegation,
-    String evidencesPDF,
-    String evidencesImages,
-    String caseIdentifier,
-    boolean open
+        long caseId,
+        long userId,
+        Long lawyerId,
+        String title,
+        String category,
+        String description,
+        Alegation alegation,
+        String evidencesPDF,
+        String evidencesImages,
+        String caseIdentifier,
+        boolean open
 ) {
-
 }

--- a/backend/src/main/java/com/justice/justiceforall/dto/casesdto/CreateCaseCommand.java
+++ b/backend/src/main/java/com/justice/justiceforall/dto/casesdto/CreateCaseCommand.java
@@ -6,13 +6,14 @@ import lombok.With;
 
 @With
 public record CreateCaseCommand(
-    String title,
-    String category,
-    String description,
-    Alegation alegation,
-    String evicendesPDF,
-    String evidenceImage,
-    String caseIdentifier,
-    boolean open
+        Long userId,
+        String title,
+        String category,
+        String description,
+        Alegation alegation,
+        String evidencesPDF,
+        String evidenceImage,
+        String caseIdentifier,
+        boolean open
 ) {
 }

--- a/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterCasesRequest.java
+++ b/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterCasesRequest.java
@@ -1,0 +1,10 @@
+package com.justice.justiceforall.dto.casesdto;
+
+public record FilterCasesRequest(
+        Boolean open,
+        Long userId,
+        Long lawyerId,
+        String category,
+        String description
+) {
+}

--- a/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterCasesRequest.java
+++ b/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterCasesRequest.java
@@ -5,6 +5,7 @@ public record FilterCasesRequest(
         Long userId,
         Long lawyerId,
         String category,
-        String description
+        String description,
+        FilterPaging paging
 ) {
 }

--- a/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterPaging.java
+++ b/backend/src/main/java/com/justice/justiceforall/dto/casesdto/FilterPaging.java
@@ -1,0 +1,7 @@
+package com.justice.justiceforall.dto.casesdto;
+
+public record FilterPaging(
+        int pageNumber,
+        int pageSize
+) {
+}

--- a/backend/src/main/java/com/justice/justiceforall/entity/casesentity/CaseEntity.java
+++ b/backend/src/main/java/com/justice/justiceforall/entity/casesentity/CaseEntity.java
@@ -30,26 +30,26 @@ public class CaseEntity {
   @Column(name = "case_id")
   private Long id;
 
-  @Column(name = "case_title", nullable = false, length = 30)
+  @Column(nullable = false, length = 30)
   private String title;
 
-  @Column(name = "case_category", nullable = false, length = 100)
+  @Column(nullable = false, length = 100)
   private String category;
 
   @Column(nullable = false, length = 500)
   private String description;
 
-  @Column(name = "alegation", nullable = false)
+  @Column(nullable = false)
   @Enumerated(value = EnumType.STRING)
   private Alegation alegation;
   
-  @Column(nullable = false, length = 120)
+  @Column(name = "evidences_pdf", length = 120)
   private String evidencesPdf;
 
-  @Column(nullable = false, length = 120)
+  @Column(name = "evidence_image", length = 120)
   private String evidenceImage;
 
-  @Column(nullable = false, length = 120)
+  @Column(name = "case_identifier", nullable = false, length = 120)
   private String caseIdentifier;
 
   @Column(nullable = false)

--- a/backend/src/main/java/com/justice/justiceforall/entity/casesentity/CaseEntity.java
+++ b/backend/src/main/java/com/justice/justiceforall/entity/casesentity/CaseEntity.java
@@ -1,13 +1,6 @@
 package com.justice.justiceforall.entity.casesentity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -29,6 +22,12 @@ public class CaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "case_id")
   private Long id;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "lawyer_id")
+  private Long lawyerId;
 
   @Column(nullable = false, length = 30)
   private String title;

--- a/backend/src/main/java/com/justice/justiceforall/repository/CasesRepository.java
+++ b/backend/src/main/java/com/justice/justiceforall/repository/CasesRepository.java
@@ -2,13 +2,31 @@ package com.justice.justiceforall.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.justice.justiceforall.entity.casesentity.CaseEntity;
+import org.springframework.data.repository.query.Param;
 
 
 public interface CasesRepository extends CrudRepository<CaseEntity, Long> {
 
     List<CaseEntity> findByCategory(String category);
     List<CaseEntity> findAll();
+    @Query(value = "SELECT * FROM cases c WHERE " +
+            "(:open is null or c.open = :open) AND " +
+            "(:userId is null or c.user_id = :userId) AND " +
+            "(:lawyerId is null or c.lawyer_id = :lawyerId) AND " +
+            "(:category is null or c.category ilike :category) AND " +
+            "(:description is null or lower(c.description) SIMILAR TO '%(' || REPLACE(lower(:description), ' ', '%') || ')%');",
+            nativeQuery = true)
+    List<CaseEntity> filterCases(
+            @Param("open") Boolean open,
+            @Param("userId") Long userId,
+            @Param("lawyerId") Long lawyerId,
+            @Param("category") String category,
+            @Param("description") String description,
+            Pageable pageable
+    );
  }

--- a/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseService.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseService.java
@@ -2,9 +2,13 @@ package com.justice.justiceforall.service.casesservice;
 
 import com.justice.justiceforall.dto.casesdto.Case;
 import com.justice.justiceforall.dto.casesdto.CreateCaseCommand;
+import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
+
+import java.util.List;
 
 public interface CaseService {
     Case createCase(CreateCaseCommand createCaseCommand);
+    List<Case> getFilteredCases(FilterCasesRequest filterCasesRequest);
     Case getCaseById(Long id);
     Case[] getAllCases();
     Case[] getCasesByCategory(String category);

--- a/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
@@ -9,6 +9,8 @@ import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.justice.justiceforall.controllers.CaseController;
@@ -40,7 +42,17 @@ public class CaseServiceImpl implements CaseService {
 
     @Override
     public List<Case> getFilteredCases(FilterCasesRequest filterCasesRequest) {
-        return Collections.emptyList();
+        logger.info("Filtering cases with filter {}", filterCasesRequest);
+        return casesRepository.filterCases(
+                        filterCasesRequest.open(),
+                        filterCasesRequest.userId(),
+                        filterCasesRequest.lawyerId(),
+                        filterCasesRequest.category(),
+                        filterCasesRequest.description(),
+                        PageRequest.of(filterCasesRequest.paging().pageNumber() - 1, filterCasesRequest.paging().pageSize())
+                ).stream()
+                .map(this::getCaseFromEntity)
+                .toList();
     }
 
     @Override

--- a/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
@@ -1,9 +1,11 @@
 package com.justice.justiceforall.service.casesservice;
 
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +36,11 @@ public class CaseServiceImpl implements CaseService {
         var savedEntity = casesRepository.save(getCaseEntity(createCaseCommand));
         logger.info("Created a new Case with ID {}", savedEntity.getId());
         return getCaseFromEntity(savedEntity);
+    }
+
+    @Override
+    public List<Case> getFilteredCases(FilterCasesRequest filterCasesRequest) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/casesservice/CaseServiceImpl.java
@@ -18,76 +18,79 @@ import com.justice.justiceforall.repository.CasesRepository;
 @Service
 public class CaseServiceImpl implements CaseService {
 
-  @Autowired
-  private CasesRepository casesRepository;
-  
-  private final Logger logger = LoggerFactory.getLogger(CaseController.class);
+    @Autowired
+    private CasesRepository casesRepository;
 
-  @Override
-  public Case createCase(CreateCaseCommand createCaseCommand) {
-    logger.info(
-        "Creating a new Case of title {} and category {}",
-        createCaseCommand.title(),
-        createCaseCommand.category()
-    );
-    CreateCaseValidator.validateNewCase(createCaseCommand);
-    var savedEntity = casesRepository.save(getCaseEntity(createCaseCommand));
-    logger.info("Created a new Case with ID {}", savedEntity.getId());
-    return getCaseFromEntity(savedEntity);
-  }
+    private final Logger logger = LoggerFactory.getLogger(CaseController.class);
 
-  @Override
-  public Case getCaseById(Long id) {
-    Optional<CaseEntity> caseEntityOptional = casesRepository.findById(id);
-    if (caseEntityOptional.isPresent()) {
-      CaseEntity caseEntity = caseEntityOptional.get();
-      return getCaseFromEntity(caseEntity);
+    @Override
+    public Case createCase(CreateCaseCommand createCaseCommand) {
+        logger.info(
+                "Creating a new Case of title {} and category {}",
+                createCaseCommand.title(),
+                createCaseCommand.category()
+        );
+        CreateCaseValidator.validateNewCase(createCaseCommand);
+        var savedEntity = casesRepository.save(getCaseEntity(createCaseCommand));
+        logger.info("Created a new Case with ID {}", savedEntity.getId());
+        return getCaseFromEntity(savedEntity);
     }
-    return null;
-  }
 
-  @Override
-  public Case[] getAllCases() {
-    List<CaseEntity> caseEntities = casesRepository.findAll();
-    return caseEntities.stream()
-            .map(this::getCaseFromEntity)
-            .toArray(Case[]::new);
-  }
+    @Override
+    public Case getCaseById(Long id) {
+        Optional<CaseEntity> caseEntityOptional = casesRepository.findById(id);
+        if (caseEntityOptional.isPresent()) {
+            CaseEntity caseEntity = caseEntityOptional.get();
+            return getCaseFromEntity(caseEntity);
+        }
+        return null;
+    }
 
-  @Override
-  public Case[] getCasesByCategory(String category) {
-	List<CaseEntity> caseEntities = casesRepository.findByCategory(category);
-	return caseEntities.stream()
-            .map(this::getCaseFromEntity)
-            .toArray(Case[]::new);
-  }
-  
-  private CaseEntity getCaseEntity(CreateCaseCommand createCaseCommand) {
-    return CaseEntity.builder()
-        .title(createCaseCommand.title())
-        .category(createCaseCommand.category())
-        .description(createCaseCommand.description())
-        .alegation(createCaseCommand.alegation())
-        .evidencesPdf(createCaseCommand.evicendesPDF())
-        .evidenceImage(createCaseCommand.evidenceImage())
-        .caseIdentifier(createCaseCommand.caseIdentifier())
-        .open(createCaseCommand.open())
-        .build();
-  }
+    @Override
+    public Case[] getAllCases() {
+        List<CaseEntity> caseEntities = casesRepository.findAll();
+        return caseEntities.stream()
+                .map(this::getCaseFromEntity)
+                .toArray(Case[]::new);
+    }
 
-  private Case getCaseFromEntity(CaseEntity entity) {
-    return new Case(
-    		entity.getId(),
-    		entity.getTitle(),
-    		entity.getCategory(),
-    		entity.getDescription(),
-    		entity.getAlegation(),
-    		entity.getEvidencesPdf(),
-    		entity.getEvidenceImage(),
-    		entity.getCaseIdentifier(),
-    		entity.isOpen()
-    		);
-  }
+    @Override
+    public Case[] getCasesByCategory(String category) {
+        List<CaseEntity> caseEntities = casesRepository.findByCategory(category);
+        return caseEntities.stream()
+                .map(this::getCaseFromEntity)
+                .toArray(Case[]::new);
+    }
+
+    private CaseEntity getCaseEntity(CreateCaseCommand createCaseCommand) {
+        return CaseEntity.builder()
+                .userId(createCaseCommand.userId())
+                .title(createCaseCommand.title())
+                .category(createCaseCommand.category())
+                .description(createCaseCommand.description())
+                .alegation(createCaseCommand.alegation())
+                .evidencesPdf(createCaseCommand.evidencesPDF())
+                .evidenceImage(createCaseCommand.evidenceImage())
+                .caseIdentifier(createCaseCommand.caseIdentifier())
+                .open(createCaseCommand.open())
+                .build();
+    }
+
+    private Case getCaseFromEntity(CaseEntity entity) {
+        return new Case(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getLawyerId(),
+                entity.getTitle(),
+                entity.getCategory(),
+                entity.getDescription(),
+                entity.getAlegation(),
+                entity.getEvidencesPdf(),
+                entity.getEvidenceImage(),
+                entity.getCaseIdentifier(),
+                entity.isOpen()
+        );
+    }
 
 
 }

--- a/backend/src/main/java/com/justice/justiceforall/service/casesservice/casevalidator/FileFormatValidator.java
+++ b/backend/src/main/java/com/justice/justiceforall/service/casesservice/casevalidator/FileFormatValidator.java
@@ -13,7 +13,7 @@ public class FileFormatValidator extends BaseCreatorHandler<CreateCaseCommand>{
 	
 	@Override
 	public void validate(CreateCaseCommand input) {
-		if(!this.isFileStackURL(input.evicendesPDF()) || !this.isFileStackURL(input.evidenceImage())) {
+		if(!this.isFileStackURL(input.evidencesPDF()) || !this.isFileStackURL(input.evidenceImage())) {
 			throw new InvalidCaseFieldException("The files url are not in the rigth format.");
 		};
 	    toNext(input);

--- a/backend/src/main/resources/db/migration/V2__create_case_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_case_table.sql
@@ -1,5 +1,7 @@
 CREATE TABLE cases(
     case_id serial primary key,
+	user_id int not null,
+	lawyer_id int,
     title varchar(30) not null,
     category varchar(100) not null,
     description text not null,
@@ -7,5 +9,13 @@ CREATE TABLE cases(
     evidences_pdf varchar(120),
     evidence_image varchar(120),
     case_identifier varchar(120),
-    open boolean not null
+    open boolean not null,
+	constraint fk_user_id
+		foreign key(user_id)
+		references users(user_id)
+		on delete cascade,
+	constraint fk_lawyer_id
+	    foreign key(lawyer_id)
+	    references users(user_id)
+	    on delete set null
 );

--- a/backend/src/main/resources/db/migration/V2__create_case_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_case_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE cases(
+    case_id serial primary key,
+    title varchar(30) not null,
+    category varchar(100) not null,
+    description text not null,
+    alegation varchar(20) not null,
+    evidences_pdf varchar(120),
+    evidence_image varchar(120),
+    case_identifier varchar(120),
+    open boolean not null
+);

--- a/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import com.justice.justiceforall.helper.cases.FilterCasesRequestFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +46,21 @@ public class CaseControllerTests {
 
         verify(caseService, times(1)).createCase(createCaseCommand.withUserId(loggedUserId));
         assertEquals(case1, response);
+    }
+
+    @Test
+    void ensureTheFilteredSearchCallsTheServiceWithProperArguments() {
+        var filter = FilterCasesRequestFixture.getRandom();
+        when(caseService.getFilteredCases(filter)).thenReturn(List.of());
+        var response = caseController.getCases(
+                filter.open(),
+                filter.userId(),
+                filter.lawyerId(),
+                filter.category(),
+                filter.description()
+        );
+        verify(caseService, times(1)).getFilteredCases(filter);
+        assertEquals(List.of(), response);
     }
 
     @Test

--- a/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,53 +27,54 @@ import com.justice.justiceforall.service.casesservice.CaseService;
 @SpringBootTest
 @ActiveProfiles("test")
 public class CaseControllerTests {
-	@Autowired
-	private CaseController caseController;
+    @Autowired
+    private CaseController caseController;
 
-	@MockBean
-	private CaseService caseService;
+    @MockBean
+    private CaseService caseService;
 
-	@Test
-	void ensureTheControllerCallsTheServiceMethod() {
-		var createCaseCommand = CreateCaseCommandFixture.correctCaseCommand();
-		var case1 = CaseFixture.correctCase();
-		
-		when(caseService.createCase(any())).thenReturn(case1);
-		
-		var response = caseController.createCase(createCaseCommand);
-		
-		verify(caseService, times(1)).createCase(createCaseCommand);
-		assertEquals(case1, response);
-	}
+    @Test
+    void ensureTheControllerCallsTheServiceMethod() {
+        var createCaseCommand = CreateCaseCommandFixture.correctCaseCommand();
+        var loggedUserId = new Random().nextLong();
+        var case1 = CaseFixture.correctCase();
 
-	@Test
+        when(caseService.createCase(any())).thenReturn(case1);
+
+        var response = caseController.createCase(loggedUserId, createCaseCommand);
+
+        verify(caseService, times(1)).createCase(createCaseCommand.withUserId(loggedUserId));
+        assertEquals(case1, response);
+    }
+
+    @Test
     void ensure_getCaseById_returns_correct_response_for_existing_case() {
-		var caseObj = CaseFixture.correctCase();
-        Long id = caseObj.getCaseId();
+        var caseObj = CaseFixture.correctCase();
+        Long id = caseObj.caseId();
         when(caseService.getCaseById(id)).thenReturn(caseObj);
-      
+
         ResponseEntity<Case> response = caseController.getCaseById(id);
-        
+
         verify(caseService, times(1)).getCaseById(id);
-        
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(caseObj, response.getBody());
     }
-	
-	@Test
+
+    @Test
     void ensure_getCaseById_return_notFound_status() {
         Long id = 5555L;
         when(caseService.getCaseById(id)).thenReturn(null);
-        
+
         ResponseEntity<Case> response = caseController.getCaseById(id);
 
         verify(caseService, times(1)).getCaseById(id);
-        
+
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
     }
-	
-	@Test
+
+    @Test
     void ensure_getAllCases_return_correct_httpStatus_and_correct_cases() {
         Case[] cases = CaseFixture.correctCases();
         when(caseService.getAllCases()).thenReturn(cases);
@@ -80,46 +82,46 @@ public class CaseControllerTests {
         ResponseEntity<List<Case>> response = caseController.getAllCases();
 
         verify(caseService, times(1)).getAllCases();
-        
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Arrays.asList(cases), response.getBody());
     }
-	
-	@Test
+
+    @Test
     void ensure_getAllCases_return_empty_list_when_there_is_no_case() {
         when(caseService.getAllCases()).thenReturn(null);
-       
+
         ResponseEntity<List<Case>> response = caseController.getAllCases();
-        
+
         verify(caseService, times(1)).getAllCases();
-        
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Collections.emptyList(), response.getBody());
     }
-	
-	@Test
+
+    @Test
     void ensure_getCasesByCategory_returns_correct_http_response_and_list_of_cases() {
         String category = "furto";
         Case[] cases = CaseFixture.sameCategoryCases();
         when(caseService.getCasesByCategory(category)).thenReturn(cases);
-        
+
         ResponseEntity<List<Case>> response = caseController.getCasesByCategory(category);
 
         verify(caseService, times(1)).getCasesByCategory(category);
-        
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Arrays.asList(cases), response.getBody());
     }
-	
-	@Test
+
+    @Test
     void getCaseByCategory_NoCases_ReturnsOkResponseWithEmptyList() {
         String category = "trabalhista";
         when(caseService.getCasesByCategory(category)).thenReturn(null);
-        
+
         ResponseEntity<List<Case>> response = caseController.getCasesByCategory(category);
 
         verify(caseService, times(1)).getCasesByCategory(category);
-        
+
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Collections.emptyList(), response.getBody());
     }

--- a/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/controllers/CaseControllerTests.java
@@ -57,7 +57,9 @@ public class CaseControllerTests {
                 filter.userId(),
                 filter.lawyerId(),
                 filter.category(),
-                filter.description()
+                filter.description(),
+                filter.paging().pageNumber(),
+                filter.paging().pageSize()
         );
         verify(caseService, times(1)).getFilteredCases(filter);
         assertEquals(List.of(), response);

--- a/backend/src/test/java/com/justice/justiceforall/helper/cases/CaseEntityFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/cases/CaseEntityFixture.java
@@ -8,55 +8,59 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class CaseEntityFixture {
-	public CaseEntity caseWithoutId() {
-	    return new CaseEntity(
-	    		null,
-	    		"Trafico de drogas na favela do novo engenho",
-		        "Trafico",
-		        "Estudante do terceiro ano do ensino médio que"
-		        + "trabalha de jovem aprendiz esta preso por trafico"
-		        + "sem provas conclusivas",
-		        Alegation.INNOCENT,
-		        "https://cdn.filestackcontent.com/AFrHW1QRsWxmu5ZLU2qg",
-		        "https://cdn.filestackcontent.com/AFrH432W1Q432u5ZL432",
-		        "4243243243-56.2023.4.04.7000",
-		        true
-	    );
-	  }
+    public CaseEntity caseWithoutId() {
+        return new CaseEntity(
+                null,
+                10L,
+                null,
+                "Trafico de drogas na favela do novo engenho",
+                "Trafico",
+                "Estudante do terceiro ano do ensino médio que"
+                        + "trabalha de jovem aprendiz esta preso por trafico"
+                        + "sem provas conclusivas",
+                Alegation.INNOCENT,
+                "https://cdn.filestackcontent.com/AFrHW1QRsWxmu5ZLU2qg",
+                "https://cdn.filestackcontent.com/AFrH432W1Q432u5ZL432",
+                "4243243243-56.2023.4.04.7000",
+                true
+        );
+    }
 
-	  public CaseEntity caseWithId() {
-	    return new CaseEntity(
-	    		1L,
-	    		"Trafico de drogas na favela do novo engenho",
-		        "Trafico",
-		        "Estudante do terceiro ano do ensino médio que"
-		        + "trabalha de jovem aprendiz esta preso por trafico"
-		        + "sem provas conclusivas",
-		        Alegation.INNOCENT,
-		        "https://cdn.filestackcontent.com/AFrHW1QRsWxmu5ZLU2qg",
-		        "https://cdn.filestackcontent.com/AFrH432W1Q432u5ZL432",
-		        "4243243243-56.2023.4.04.7000",
-		        true
-	    );
-	  }
-	  
-	  public CaseEntity[] casesWithId() {
-		  CaseEntity case1 = caseWithId().withId(1L);
-		  CaseEntity case2 = caseWithId().withId(2L).withCategory("furto");
-		  CaseEntity case3 = caseWithId().withId(3L);
-		  
-		  CaseEntity[] cases = {case1, case2, case3};
-		  
-		  return cases;
-	  }
-	  
-	  public CaseEntity[] casesFurto() {
-		  CaseEntity case1 = caseWithId().withId(1L).withCategory("furto");
-		  CaseEntity case2 = caseWithId().withId(2L).withCategory("furto");
-		  CaseEntity case3 = caseWithId().withId(3L).withCategory("furto");
-		  
-		  CaseEntity[] cases = {case1, case2, case3};
-		  
-		  return cases;
-	  }
+    public CaseEntity caseWithId() {
+        return new CaseEntity(
+                1L,
+                10L,
+                null,
+                "Trafico de drogas na favela do novo engenho",
+                "Trafico",
+                "Estudante do terceiro ano do ensino médio que"
+                        + "trabalha de jovem aprendiz esta preso por trafico"
+                        + "sem provas conclusivas",
+                Alegation.INNOCENT,
+                "https://cdn.filestackcontent.com/AFrHW1QRsWxmu5ZLU2qg",
+                "https://cdn.filestackcontent.com/AFrH432W1Q432u5ZL432",
+                "4243243243-56.2023.4.04.7000",
+                true
+        );
+    }
+
+    public CaseEntity[] casesWithId() {
+        CaseEntity case1 = caseWithId().withId(1L);
+        CaseEntity case2 = caseWithId().withId(2L).withCategory("furto");
+        CaseEntity case3 = caseWithId().withId(3L);
+
+        CaseEntity[] cases = {case1, case2, case3};
+
+        return cases;
+    }
+
+    public CaseEntity[] casesFurto() {
+        CaseEntity case1 = caseWithId().withId(1L).withCategory("furto");
+        CaseEntity case2 = caseWithId().withId(2L).withCategory("furto");
+        CaseEntity case3 = caseWithId().withId(3L).withCategory("furto");
+
+        CaseEntity[] cases = {case1, case2, case3};
+
+        return cases;
+    }
 }

--- a/backend/src/test/java/com/justice/justiceforall/helper/cases/CaseFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/cases/CaseFixture.java
@@ -10,6 +10,8 @@ public class CaseFixture {
 	public Case correctCase() {
 	    return new Case(
 	    		1L,
+				10L,
+				null,
 	    		"Trafico de drogas na favela do novo engenho",
 		        "Trafico",
 		        "Estudante do terceiro ano do ensino médio que"

--- a/backend/src/test/java/com/justice/justiceforall/helper/cases/CreateCaseCommandFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/cases/CreateCaseCommandFixture.java
@@ -9,6 +9,7 @@ import lombok.experimental.UtilityClass;
 public class CreateCaseCommandFixture {
 	public CreateCaseCommand correctCaseCommand() {
 	    return new CreateCaseCommand(
+				10L,
 	        "Trafico de drogas na favela do novo engenho",
 	        "Trafico",
 	        "Estudante do terceiro ano do ensino médio que"
@@ -23,7 +24,7 @@ public class CreateCaseCommandFixture {
 	  }
 	
 	public CreateCaseCommand createWithInvalidFileUrl() {
-		return correctCaseCommand().withEvicendesPDF("http://localhost:4200");
+		return correctCaseCommand().withEvidencesPDF("http://localhost:4200");
 	}
 	
 	public CreateCaseCommand createWithInvalidTitle() {

--- a/backend/src/test/java/com/justice/justiceforall/helper/cases/FilterCasesRequestFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/cases/FilterCasesRequestFixture.java
@@ -1,6 +1,7 @@
 package com.justice.justiceforall.helper.cases;
 
 import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
+import com.justice.justiceforall.dto.casesdto.FilterPaging;
 import lombok.experimental.UtilityClass;
 import org.junit.platform.commons.util.StringUtils;
 
@@ -15,7 +16,11 @@ public class FilterCasesRequestFixture {
                 new Random().nextLong(),
                 new Random().nextLong(),
                 "furto",
-                "caso furto"
+                "caso furto",
+                new FilterPaging(
+                        new Random().nextInt(1, 20),
+                        new Random().nextInt(1, 200)
+                )
         );
     }
 }

--- a/backend/src/test/java/com/justice/justiceforall/helper/cases/FilterCasesRequestFixture.java
+++ b/backend/src/test/java/com/justice/justiceforall/helper/cases/FilterCasesRequestFixture.java
@@ -1,0 +1,21 @@
+package com.justice.justiceforall.helper.cases;
+
+import com.justice.justiceforall.dto.casesdto.FilterCasesRequest;
+import lombok.experimental.UtilityClass;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.util.Random;
+
+@UtilityClass
+public class FilterCasesRequestFixture {
+
+    public FilterCasesRequest getRandom() {
+        return new FilterCasesRequest(
+                new Random().nextBoolean(),
+                new Random().nextLong(),
+                new Random().nextLong(),
+                "furto",
+                "caso furto"
+        );
+    }
+}

--- a/backend/src/test/java/com/justice/justiceforall/service/casesservice/CaseServiceTests.java
+++ b/backend/src/test/java/com/justice/justiceforall/service/casesservice/CaseServiceTests.java
@@ -11,10 +11,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.justice.justiceforall.helper.cases.FilterCasesRequestFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.justice.justiceforall.helper.cases.CaseFixture;
@@ -44,6 +46,23 @@ public class CaseServiceTests {
 		
 		assertEquals(CaseFixture.correctCase(), response);
 	}
+
+    @Test
+    void ensureTheGetFilteredCasesRepositoryQueryIsCalledWithCorrectArguments() {
+        var caseEntities = Arrays.stream(CaseEntityFixture.casesWithId()).toList();
+        when(casesRepository.filterCases(any(), any(), any(), any(), any(), any())).thenReturn(caseEntities);
+        var filter = FilterCasesRequestFixture.getRandom();
+        var response = caseService.getFilteredCases(filter);
+        verify(casesRepository, times(1)).filterCases(
+                filter.open(),
+                filter.userId(),
+                filter.lawyerId(),
+                filter.category(),
+                filter.description(),
+                PageRequest.of(filter.paging().pageNumber() - 1, filter.paging().pageSize())
+        );
+        assertEquals(caseEntities.size(), response.size());
+    }
 
 	@Test
     public void test_getCaseById_when_id_exist() {


### PR DESCRIPTION
Esse PR adiciona um endpoint para permitir a filtragem de Casos.
A filtragem leva em conta os seguintes parâmetros:
- open: para saber se o caso está em aberto ou não
- userId: para filtrar os casos de um determinado Usuário
- lawyerId: para filtrar os casos que estão com um dado advogado
- category: para filtrar os casos por categoria
- description: para filtrar casos que possuam determinadas palavras na descrição

Além disso, o endpoint também implementa a paginação para facilitar a visualização de resultados. Para a paginação, informa-se a "page" (a partir de 1) e o "size" (inteiro positivo) que indica o tamanho de cada página.